### PR TITLE
hotfix everything

### DIFF
--- a/validator/benchmark_guard_on_dataset.py
+++ b/validator/benchmark_guard_on_dataset.py
@@ -57,25 +57,21 @@ def evaluate_embeddings_guard_on_dataset(test_prompts: List[str], guard: Guard, 
     for prompt in test_prompts:
         try:
             start_time = time.perf_counter()
-            try:
-                response = guard(
-                    llm_api=openai.chat.completions.create,
-                    prompt=prompt,
-                    model="gpt-3.5-turbo",
-                    max_tokens=1024,
-                    temperature=0.5,
-                    metadata={
-                        "user_input": prompt,
-                    }
-                )
-                if response.validation_passed:
-                    num_passed_guard += 1
-                else:
-                    num_failed_guard += 1
-            except Exception as e:
+            response = guard(
+                llm_api=openai.chat.completions.create,
+                prompt=prompt,
+                model="gpt-3.5-turbo",
+                max_tokens=1024,
+                temperature=0.5,
+                metadata={
+                    "user_input": prompt,
+                }
+            )
+            latency_measurements.append(time.perf_counter() - start_time)
+            if response.validation_passed:
+                num_passed_guard += 1
+            else:
                 num_failed_guard += 1
-            finally:
-                latency_measurements.append(time.perf_counter() - start_time)
             total = num_passed_guard + num_failed_guard
             if outfile is not None:
                 debug_text = f"""\nprompt:\n{prompt}\nresponse:\n{response}\n{100 * num_failed_guard / total:.2f}% of {total} 
@@ -99,7 +95,11 @@ def benchmark_arize_jailbreak_embeddings_validator(train_prompts: List[str], jai
         original prompt and validator response.
     """
     # Set up Guard
-    guard = Guard().use(JailbreakEmbeddings, threshold=0.2, on="prompt", on_fail="exception", prompt_sources=train_prompts)
+    guard = Guard.from_string(
+        validators=[
+            JailbreakEmbeddings(threshold=0.2, validation_method="full", on_fail="refrain", sources=train_prompts)
+        ],
+    )
     
     # Evaluate Guard on dataset of jailbreak prompts
     num_passed_guard, num_failed_guard, latency_measurements = evaluate_embeddings_guard_on_dataset(

--- a/validator/main.py
+++ b/validator/main.py
@@ -34,6 +34,20 @@ def _embed_function(text: Union[str, List[str]]) -> np.ndarray:
     return np.array(embeddings_out)
 
 
+def get_prompts(filename: str) -> List[str]:
+    """Get prompts from local file.
+    
+    :param filename: Name of CSV file (excluding directory), e.g. my_file.csv.
+
+    :return: List of prompt strings, e.g. ["my prompt 1", "my prompt 2", ..., "my prompt 500"]
+    """
+    script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
+    # Dataset from public repo associated with arxiv paper https://github.com/verazuo/jailbreak_llms
+    file_path = os.path.join(script_dir, filename)
+    prompts = pd.read_csv(file_path)["prompt"].tolist()
+    return prompts
+
+
 class EmbeddingChunkStrategy(Enum):
     """Chunk strategy used in get_chunks_from_text when creating embeddings."""
     SENTENCE = 0
@@ -48,60 +62,47 @@ class JailbreakEmbeddings(Validator):
     embeddings from Arize AI."""
 
     def __init__(
-            self,
-            prompt_sources: List[str] = None,
-            threshold: float = 0.2,
-            on_fail: Optional[Callable] = None,
-            embed_function: Optional[Callable] = _embed_function,
-            chunk_strategy: EmbeddingChunkStrategy = EmbeddingChunkStrategy.SENTENCE,
-            chunk_size: int = 100,
-            chunk_overlap: int = 20,
+        self,
+        threshold: float = 0.2,
+        validation_method: str = "full",
+        on_fail: Optional[Callable] = None,
+        **kwargs,
     ):
-        """Initialize Arize AI Guard against jailbreak embeddings.
-
-        :param prompt_sources: Examples of jailbreak attempts that we want to Guard against. These examples will
-            be embedded by our embed_function. If the Guard sees a user input message with embeddings that are close
-            to any of the embedded chunks from our jailbreak examples, then the Guard will flag the jailbreak attempt.
-            We recommend adding 10 examples. Fewer examples afffects performance, while additional examples hurts latency.
-            If user does not provide examples, we use our own dataset.
-        :param threshold: Float values between 0.0 and 1.0. Defines the threshold at which a new user input is close
-            enough to an embedded prompt_sources chunk that the Guard flags a jailbreak attempt. The distance is measured
-            as the cosine distance between embeddings.
-        :on_fail: Inherited from Validator.
-        :embed_function: Embedding function used to embed both the prompt_sources and live user input.
-        :chunk_strategy: The strategy to use for chunking when calling Guardrails AI. Strategies include sentence,
-            word, character or token. Details in get_chunks_from_text.
-        :chunk_size: Usage defined by Guardrails AI. The size of each chunk. If the chunk_strategy is "sentences",
-            this is the number of sentences per chunk. If the chunk_strategy is "characters", this is the number of 
-            characters per chunk, and so on. Defaults to 100 through trial-and-error.
-        :chunk_overlap: The number of characters to overlap between chunks. If the chunk_strategy is "sentences", this 
-            is the number of sentences to overlap between chunks. Defaults to 20 through trial-and-error.
-        """
-        super().__init__(on_fail, prompt_sources=prompt_sources, threshold=threshold, embed_function=embed_function, chunk_strategy=chunk_strategy, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+        super().__init__(
+            on_fail, threshold=threshold, validation_method=validation_method, **kwargs
+        )
         self._threshold = float(threshold)
+        self._validation_method = "full"
+        self.sources = kwargs.get("sources", None)
         
-        if prompt_sources is None:
-            import os
+        # Use Arize AI prompts if user does not provide their own.
+        if self.sources is None:
             script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
             # Dataset from public repo associated with arxiv paper https://github.com/verazuo/jailbreak_llms
             file_path = os.path.join(script_dir, 'jailbreak_prompts_2023_05_07.csv')
             # We recommend at least 10 examples. Additional examples may adversely affect latency.
             self.sources = pd.read_csv(file_path)["prompt"].tolist()[-10:]
+
         # Validate user inputs
-        for prompt in prompt_sources:
+        for prompt in self.sources:
             if not prompt or not isinstance(prompt, str):
                 raise ValueError(f"Prompt example: {prompt} is invalid. Must contain valid string data.")
-            
-        self.embed_function = embed_function
+
+        self.embed_function = kwargs.get("embed_function", _embed_function)
+
+        # Check chunking strategy
+        chunk_strategy = kwargs.get("chunk_strategy",EmbeddingChunkStrategy.SENTENCE.name.lower())
+        chunk_size = kwargs.get("chunk_size", 100)
+        chunk_overlap = kwargs.get("chunk_overlap", 20)
 
         chunks = [
-            get_chunks_from_text(source, chunk_strategy.name.lower(), chunk_size, chunk_overlap)
-            for source in prompt_sources
+            get_chunks_from_text(source, chunk_strategy, chunk_size, chunk_overlap)
+            for source in self.sources
         ]
         self.chunks = list(itertools.chain.from_iterable(chunks))
 
         # Create embeddings
-        self.source_embeddings = np.array(self.embed_function(self.chunks)).squeeze()  
+        self.source_embeddings = np.array(self.embed_function(self.chunks)).squeeze()
 
     def validate(self, value: Any, metadata: Dict[str, Any]) -> ValidationResult:
         """Validation function for the JailbreakEmbeddings validator. If the cosine distance
@@ -115,8 +116,8 @@ class JailbreakEmbeddings(Validator):
 
         :return: PassResult or FailResult.
         """
-        closest_chunk, lowest_distance = self.query_vector_collection(text=value, k=1)[0]
-        metadata["lowest_cosine_distance"] = lowest_distance
+        closest_chunk, lowest_distance = self.query_vector_collection(text=metadata.get("user_input"), k=1)[0]
+        metadata["highest_similarity_score"] = lowest_distance
         metadata["similar_jailbreak_phrase"] = closest_chunk
         metadata["user prompt"] = value
         if lowest_distance < self._threshold:
@@ -166,16 +167,3 @@ class JailbreakEmbeddings(Validator):
         closest_chunks = [self.chunks[j] for j in low_to_high_ind]
 
         return list(zip(closest_chunks, lowest_distances))
-
-def get_prompts(filename: str) -> List[str]:
-    """Get prompts from local file.
-    
-    :param filename: Name of CSV file (excluding directory), e.g. my_file.csv.
-
-    :return: List of prompt strings, e.g. ["my prompt 1", "my prompt 2", ..., "my prompt 500"]
-    """
-    script_dir = os.path.dirname(__file__)  # Get the directory where the script is located
-    # Dataset from public repo associated with arxiv paper https://github.com/verazuo/jailbreak_llms
-    file_path = os.path.join(script_dir, filename)
-    prompts = pd.read_csv(file_path)["prompt"].tolist()
-    return prompts


### PR DESCRIPTION
Revert changes that were throwing errors (resolved in this hotfix PR)

```
gd) (⎈|mynamespace:juliagomes)juliagomes@Julias-MacBook-Pro jailbreak-embeddings % python3 validator/benchmark_guard_on_dataset.py
:key: Enter your OpenAI API key: 
/opt/homebrew/lib/python3.12/site-packages/guardrails/validators/__init__.py:51: FutureWarning: 
    Importing validators from `guardrails.validators` is deprecated.
    All validators are now available in the Guardrails Hub. Please install
    and import them from the hub instead. All validators will be
    removed from this module in the next major release.

    Install with: `guardrails hub install hub://<namespace>/<validator_name>`
    Import as: from guardrails.hub import `ValidatorName`
    
  warn(
Traceback (most recent call last):
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 149, in <module>
    main()
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 140, in main
    benchmark_arize_jailbreak_embeddings_validator(
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 105, in benchmark_arize_jailbreak_embeddings_validator
    num_passed_guard, num_failed_guard, latency_measurements = evaluate_embeddings_guard_on_dataset(
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 81, in evaluate_embeddings_guard_on_dataset
    debug_text = f"""\nprompt:\n{prompt}\nresponse:\n{response}\n{100 * num_failed_guard / total:.2f}% of {total} 
                                                      ^^^^^^^^
UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
```

```
Traceback (most recent call last):
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 145, in <module>
    main()
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 136, in main
    benchmark_arize_jailbreak_embeddings_validator(
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 101, in benchmark_arize_jailbreak_embeddings_validator
    num_passed_guard, num_failed_guard, latency_measurements = evaluate_embeddings_guard_on_dataset(
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/juliagomes/jailbreak-embeddings/validator/benchmark_guard_on_dataset.py", line 60, in evaluate_embeddings_guard_on_dataset
    response = guard(
               ^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/guard.py", line 692, in __call__
    return guard_context.run(
           ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/guard.py", line 677, in __call
    return self._call_sync(
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/guard.py", line 767, in _call_sync
    call = runner(call_log=call_log, prompt_params=prompt_params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 203, in __call__
    raise e
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 153, in __call__
    iteration = self.step(
                ^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/utils/telemetry_utils.py", line 215, in to_trace_or_not_to_trace
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 302, in step
    raise e
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 246, in step
    instructions, prompt, msg_history = self.prepare(
                                        ^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 479, in prepare
    instructions, prompt = self.prepare_prompt(
                           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 423, in prepare_prompt
    prompt = self.validate_prompt(call_log, prompt_schema, prompt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/guardrails/run/runner.py", line 365, in validate_prompt
    raise ValidationError("Prompt validation failed")
guardrails.errors.ValidationError: Prompt validation failed
```