### PR TITLE
Juliagomes/generalize guard name

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3,13 +3,13 @@
 from typing import List
 from guardrails import Guard
 import pytest
-from validator.main import JailbreakEmbeddings, get_prompts
+from validator.main import DatasetEmbeddings, get_prompts
 
 # We use 'exception' as the validator's fail action,
 #  so we expect failures to always raise an Exception
 # Learn more about corrective actions here:
 #  https://www.guardrailsai.com/docs/concepts/output/#%EF%B8%8F-specifying-corrective-actions
-guard = Guard().use(validator=JailbreakEmbeddings, on="prompt", on_fail="exception")
+guard = Guard().use(validator=DatasetEmbeddings, on="prompt", on_fail="exception")
    
 
 def test_pass():

--- a/validator/benchmark_guard_on_dataset.py
+++ b/validator/benchmark_guard_on_dataset.py
@@ -1,4 +1,4 @@
-"""Benchmark Arize JailbreakEmbeddings Guard against a dataset of regular prompts and a dataset of jailbreak prompts."""
+"""Benchmark Arize DatasetEmbeddings Guard against a dataset of regular prompts and a dataset of jailbreak prompts."""
 import os
 from getpass import getpass
 from typing import List
@@ -17,7 +17,7 @@ from guardrails import Guard
 from guardrails.llm_providers import PromptCallableException
 import openai
 
-from main import JailbreakEmbeddings, get_prompts
+from main import DatasetEmbeddings, get_prompts
 
 
 JAILBREAK_PROMPTS_FP = "jailbreak_prompts_2023_05_07.csv"
@@ -27,7 +27,7 @@ VANILLA_PROMPTS_FP = "regular_prompts_2023_05_07.csv"
 NUM_FEW_SHOT_EXAMPLES = 10
 MODEL = "gpt-3.5-turbo"
 # Output file to log debugging info. Set to None if you do not wish to add logging.
-OUTFILE = f"arize_{JailbreakEmbeddings.__name__}_guard_{MODEL}_output.txt"
+OUTFILE = f"arize_{DatasetEmbeddings.__name__}_guard_{MODEL}_output.txt"
 
 
 def append_to_file(filepath: str, text: str) -> None:
@@ -73,8 +73,8 @@ def evaluate_embeddings_guard_on_dataset(test_prompts: List[str], guard: Guard, 
             total = num_passed_guard + num_failed_guard
             if outfile is not None:
                 debug_text = f"""\nprompt:\n{prompt}\nresponse:\n{response}\n{100 * num_failed_guard / total:.2f}% of {total} 
-                    prompts failed the JailbreakEmbeddings guard.\n{100 * num_passed_guard / total:.2f}% of {total} prompts 
-                    passed the JailbreakEmbeddings guard."""
+                    prompts failed the DatasetEmbeddings guard.\n{100 * num_passed_guard / total:.2f}% of {total} prompts 
+                    passed the DatasetEmbeddings guard."""
                 append_to_file(filepath=outfile, text=debug_text)
         except PromptCallableException as e:
             # Dataset may contain a few bad apples that result in an Open AI error for invalid inputs.
@@ -84,7 +84,7 @@ def evaluate_embeddings_guard_on_dataset(test_prompts: List[str], guard: Guard, 
 
 
 def benchmark_arize_jailbreak_embeddings_validator(train_prompts: List[str], jailbreak_test_prompts: List[str], vanilla_prompts: List[str], outfile: Optional[str]):
-    """Benchmark Arize JailbreakEmbeddings Guard against a dataset of regular prompts and a dataset of jailbreak prompts.
+    """Benchmark Arize DatasetEmbeddings Guard against a dataset of regular prompts and a dataset of jailbreak prompts.
 
     :param train_prompts: Few-shot examples of jailbreak prompts.
     :param jailbreak_test_prompts: Test prompts used to evaluate the Guard. We expect the Guard to block these examples.
@@ -95,7 +95,7 @@ def benchmark_arize_jailbreak_embeddings_validator(train_prompts: List[str], jai
     # Set up Guard
     guard = Guard.from_string(
         validators=[
-            JailbreakEmbeddings(threshold=0.2, validation_method="full", on_fail="refrain", sources=train_prompts)
+            DatasetEmbeddings(threshold=0.2, validation_method="full", on_fail="refrain", sources=train_prompts)
         ],
     )
     

--- a/validator/main.py
+++ b/validator/main.py
@@ -76,7 +76,7 @@ class DatasetEmbeddings(Validator):
         self._threshold = float(threshold)
         self._validation_method = "full"
         if kwargs.get("sources") is None:
-            logging.warn("A source dataset was not provided, so using default sources of Jailbreak prompts from Arize.")
+            logging.warning("A source dataset was not provided, so using default sources of Jailbreak prompts from Arize.")
         self.sources = kwargs.get("sources", FEW_SHOT_TRAIN_PROMPTS)
         
         # Validate user inputs

--- a/validator/main.py
+++ b/validator/main.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from enum import Enum
 import pandas as pd
 import os
+import logging
 
 import numpy as np
 
@@ -57,8 +58,8 @@ class EmbeddingChunkStrategy(Enum):
     TOKEN = 3
 
 
-@register_validator(name="arize/jailbreak_embeddings", data_type="string")
-class JailbreakEmbeddings(Validator):
+@register_validator(name="arize/dataset_embeddings", data_type="string")
+class DatasetEmbeddings(Validator):
     """Validates that user-generated input does not match dataset of jailbreak
     embeddings from Arize AI."""
 
@@ -74,6 +75,8 @@ class JailbreakEmbeddings(Validator):
         )
         self._threshold = float(threshold)
         self._validation_method = "full"
+        if kwargs.get("sources") is None:
+            logging.info("A source dataset was not provided, so using default sources of Jailbreak prompts from Arize.")
         self.sources = kwargs.get("sources", FEW_SHOT_TRAIN_PROMPTS)
         
         # Validate user inputs
@@ -98,14 +101,14 @@ class JailbreakEmbeddings(Validator):
         self.source_embeddings = np.array(self.embed_function(self.chunks)).squeeze()
 
     def validate(self, value: Any, metadata: Dict[str, Any]) -> ValidationResult:
-        """Validation function for the JailbreakEmbeddings validator. If the cosine distance
+        """Validation function for the DatasetEmbeddings validator. If the cosine distance
         of the user input embeddings is below the user-specified threshold of the closest embedded chunk
         from the jailbreak examples in prompt sources, then the Guard will return FailResult. If all chunks
         are sufficiently distant, then the Guard will return PassResult.
 
-        :param value: This is the 'value' of user input. For the JailbreakEmbeddings Guard, we want
+        :param value: This is the 'value' of user input. For the DatasetEmbeddings Guard, we want
             to ensure we are validating user input, rather than LLM output, so we need to call
-            the guard with Guard().use(JailbreakEmbeddings, on="prompt")
+            the guard with Guard().use(DatasetEmbeddings, on="prompt")
 
         :return: PassResult or FailResult.
         """
@@ -118,7 +121,6 @@ class JailbreakEmbeddings(Validator):
         closest_chunk, lowest_distance = self.query_vector_collection(text=user_message, k=1)[0]
         metadata["lowest_cosine_distance"] = lowest_distance
         metadata["similar_jailbreak_phrase"] = closest_chunk
-        metadata["user prompt"] = user_message
         
         # Pass or fail Guard based on minimum cosine distance between user message and embedded jailbreak prompts.
         if lowest_distance < self._threshold:
@@ -126,10 +128,10 @@ class JailbreakEmbeddings(Validator):
             return FailResult(
                 metadata=metadata,
                 error_message=(
-                    f"""The following message triggered the Arize JailbreakEmbeddings Guard:
-                        {user_message}.
+                    f"""The following message triggered the Arize DatasetEmbeddings Guard:\n
+                        {user_message}.\n
                     
-                    The message is similar to the following text chunk in our few shot dataset of jailbreaks prompts:
+                    The message is similar to the following text chunk in our few shot dataset of jailbreaks prompts:\n
                         {closest_chunk}"""
                 ),
             )

--- a/validator/main.py
+++ b/validator/main.py
@@ -76,7 +76,7 @@ class DatasetEmbeddings(Validator):
         self._threshold = float(threshold)
         self._validation_method = "full"
         if kwargs.get("sources") is None:
-            logging.info("A source dataset was not provided, so using default sources of Jailbreak prompts from Arize.")
+            logging.warn("A source dataset was not provided, so using default sources of Jailbreak prompts from Arize.")
         self.sources = kwargs.get("sources", FEW_SHOT_TRAIN_PROMPTS)
         
         # Validate user inputs


### PR DESCRIPTION
- Rename `JailbreakEmbeddings` as `DatasetEmbeddings` to showcase generalization ability.
- Add logging to warn user when jailbreak embeddings are loaded by default because another dataset source is not provided.
- Clean up spacing in error message.
- Remove `metadata["user prompt"` because this attribute is duplicated.